### PR TITLE
Add `X-Freckle-Flags` to request headers to allow timer to load

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,11 @@
     "default_icon": "icon-19.png",
     "default_popup": "popup.html"
   },
+  "permissions":[
+    "webRequest",
+    "webRequestBlocking",
+    "https://*.letsfreckle.com/"
+  ],
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {

--- a/popup.js
+++ b/popup.js
@@ -259,6 +259,15 @@ function disconnectAccount(){
   localStorage["organisation-name"] = "";
 }
 
+// Add the header to allow content to be iframed
+chrome.webRequest.onBeforeSendHeaders.addListener(
+  function(details) {
+    details.requestHeaders.push({"name":"X-Freckle-Flags", "value": "allow-iframe"})
+    return {requestHeaders: details.requestHeaders};
+  },
+  {urls: ["<all_urls>"]},
+  ["blocking", "requestHeaders"]
+);
 
 
 


### PR DESCRIPTION
- To fix the browser extension by allowing the content in the iframe
  to load, the `X-Freckle-Flags` request header must be set to
  `allow-iframe`.

This fixes https://github.com/RobertDaleSmith/freckle-chrome-extension/issues/3
